### PR TITLE
cleanup: remove unused 'checkMemory' function

### DIFF
--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -156,10 +156,6 @@ def checkCPU(lines):
                     "Your system is below minimum specs for OBS to run and is too underpowered to livestream using software encoding. Livestreams and recordings will only run smoothly if you are using the hardware QuickSync encoder (via Settings -> Output)."]
 
 
-def checkMemory(lines):
-    ram = search('Physical Memory:', lines)
-
-
 def getOBSVersionLine(lines):
     versionLines = search('OBS', lines)
     correctLine = 0


### PR DESCRIPTION
should either do this, or come up with thresholds and actually call this (probably ok to just remove, given that systems without enough memory probably wont' have enough anything else either)