### PR TITLE
fix game mode check crashing on unknown win10 versions

### DIFF
--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -249,6 +249,9 @@ def checkGameMode(lines):
     if not verinfo or verinfo["version"] != "10.0":
         return
 
+    if verinfo["version"] == "10.0" and "release" not in verinfo:
+        return
+
     if search("Game Mode: On", lines) and verinfo["release"] < 1809:
         return [LEVEL_WARNING, "Windows 10 Game Mode",
                 """In some versions of Windows 10 (prior to version 1809), the "Game Mode" feature interferes with OBS Studio's normal functionality by starving it of CPU and GPU resources. We recommend disabling it via <a href="https://obsproject.com/wiki/How-to-disable-Windows-10-Gaming-Features#game-mode">these instructions</a>."""]
@@ -440,7 +443,7 @@ def checkWindowsVer(lines):
 
     # This is such a hack, but it's unclear how to do this better
     if verinfo["version"] == "10.0" and "release" not in verinfo:
-        msg = "You are running an unknown Windows 10 release (build %d), which means you are probably using an 'insider' build. Becaue insider builds are test versions, you may have problems that would not happen with release versions of windows." % (
+        msg = "You are running an unknown Windows 10 release (build %d), which means you are probably using an Insider build. Some checks that are applicable only to specific Windows versions will not be performed. Also, because Insider builds are test versions, you may have problems that would not happen with release versions of Windows." % (
             verinfo["build"])
         return[LEVEL_WARNING, "Windows 10 Version Unknown", msg]
 


### PR DESCRIPTION
This is a win10 (sub)version-specific check, just skip it if it's a win10 version we don't recognize, rather than crashing out and/or trying to guess what's appropriate. We also updated the 'unknown Windows 10 version' text to note that windows-version-specific checks won't be performed.
