### PR TITLE
note win10 1903/1909 uncertainty in OBS <= 24.0.3

### DIFF
--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -479,7 +479,16 @@ def checkWindowsVer(lines):
             verinfo["name"], verinfo["EoS"].strftime("%Y-%m-%d"))
         return [LEVEL_WARNING, wv, msg]
 
-    # else
+    # special case for OBS 24.0.3 and earlier, which report Windows 10/1909
+    # as being Windows 10/1903
+    versionString = getOBSVersionString(lines)
+    if parse_version(versionString) <= parse_version("24.0.3"):
+        if verinfo["version"] == "10.0" and verinfo["release"] == 1903:
+            return [LEVEL_INFO, "Windows 10 1903/1909",
+                    "Due to a bug in OBS versions 24.0.3 and earlier, the exact release of Windows 10 you are using cannot be determined. You are using either release 1903, or release 1909. Fortunately, there were no major changes in behavior between Windows 10 release 1903 and Windows 10 release 1909, and instructions given here for release 1903 can also be used for release 1909, and vice versa."]
+
+    # our windows version isn't out of support, so just say what version the user has and when
+    # it actually does go out of support
     wv = "%s (OK)" % (verinfo["name"])
 
     if "EoS" in verinfo:


### PR DESCRIPTION
In 24.0.3 (and earlier), the windows build information provided in the OBS log is the same for Windows 10 release 1903, and Windows 10 release 1909. This change has the log analyzer report the windows version as "1903/1909" to avoid stating potentially incorrect information as though it were fact, and hopefully removing a modicum of confusion in the process.