### PR TITLE
update with new COVID-19 inspired win10 EoS dates

### DIFF
--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -391,7 +391,7 @@ win10versions = {
         "release": 1809,
         "name": "Windows 10 1809",
         "date": datetime.date(2018, 11, 13),
-        "EoS": datetime.date(2020, 5, 12),
+        "EoS": datetime.date(2020, 11, 10),
     },
     18362: {
         "release": 1903,


### PR DESCRIPTION
Per https://support.microsoft.com/en-us/help/4557164/lifecycle-changes-to-end-of-support-and-servicing-dates

We only track non-enterprise support dates, so only win10/1809 needs
to be updated.
