### PR TITLE
don't crash out on misformated audio buffering lines

### DIFF
--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -582,24 +582,45 @@ def checkCustom(lines):
                 """Custom FFMPEG output is in use. Only absolute professionals should use this. If you got your settings from a YouTube video advertising "Absolute best OBS settings" then we recommend using one of the presets in Simple output mode instead."""]
 
 
-def checkAudio(lines):
-    buffering = search('total audio buffering is now', lines)
+audiobuf_re = re.compile(r"""
+    (?i)
+    adding \s (?P<added> \d+) \s milliseconds \s of \s audio \s buffering
+    , \s
+    total \s audio \s buffering \s is \s now \s (?P<total> \d+) \s milliseconds
+    (
+        \s
+        \( source: (?P<source> .*) \)
+    )?
+    $
+    """, re.VERBOSE)
+
+
+def checkAudioBuffering(lines):
     maxBuffering = search('Max audio buffering reached!', lines)
     if (len(maxBuffering) > 0):
+        # This doesn't correspond to a specific amount of time -- it's
+        # emitted if the delay is greater than MAX_BUFFERING_TICKS, and that
+        # amount of time varies by sample rate. Unfortunately, the max
+        # buffering reached message doesn't directly say which audio source
+        # was the offender. Is it worth just ditching this check and using
+        # the "greater than 500ms" check, which could potentially also easily
+        # know the specific device?
         return [LEVEL_CRITICAL, "Max Audio Buffering",
                 "Audio buffering hit the maximum value. This is an indicator of very high system load, will affect stream latency, and may even cause individual audio sources to stop working. Keep an eye on CPU usage especially, and close background programs if needed. Restart OBS to reset buffering."]
-    vals = []
+
+    buffering = search('total audio buffering is now', lines)
+    vals = [0, ]
     if (len(buffering) > 0):
         for i in buffering:
-            if (i.split()[12] == "now"):
-                vals.append(int(i.split()[13]))
-            else:
-                vals.append(int(i.split()[12]))
+            m = audiobuf_re.search(i)
+            if m:
+                vals.append(int(m.group("total")))
+
         if (max(vals) > 500):
             return [LEVEL_WARNING, "High Audio Buffering",
                     "Audio buffering reached values above 500ms. This is an indicator of very high system load and will affect stream latency. Keep an eye on CPU usage especially, and close background programs if needed. Restart OBS to reset buffering."]
-    else:
-        return None
+
+    return None
 
 
 def checkMulti(lines):
@@ -956,7 +977,7 @@ def doAnalysis(url=None, filename=None):
             messages.append(checkMP4(logLines))
             messages.append(checkPreset(logLines))
             messages.append(checkCustom(logLines))
-            messages.append(checkAudio(logLines))
+            messages.append(checkAudioBuffering(logLines))
             messages.append(checkDrop(logLines))
             messages.append(checkRenderLag(logLines))
             messages.append(checkEncodeError(logLines))


### PR DESCRIPTION
Because we don't have a mutex on log output, lines can sometimes get
mixed together. If this happened for an "adding XX milliseconds of audio
buffering" line, the analyzer would crash out because the millisecond count
wasn't in the string position it should have been.

We now parse with a regex, and give ourselves a little bit of framework for
doing fancier things in the future.
