### PR TITLE
Add critical warning for HAGS

### DIFF
--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -408,6 +408,10 @@ def checkGameMode(lines):
         return [LEVEL_INFO, "Windows 10 Game Mode",
                 """In Windows 10 versions 1809 and newer, we recommend that "Game Mode" be enabled for maximum gaming performance. Game Mode can be enabled via the Windows 10 "Settings" app, under Gaming > <a href="ms-settings:gaming-gamemode">Game Mode</a>."""]
 
+def checkWin10Hags(lines):
+    if search('Hardware GPU Scheduler: On', lines):
+        return [LEVEL_CRITICAL, "Hardware-accelerated GPU Scheduler",
+                """The new Windows 10 Hardware-accelerated GPU scheduling ("HAGS") added with version 2004 is currently known to cause performance and capture issues with OBS, games and overlay tools. It's a new and experimental feature and we recommend disabling it via <a href="ms-settings:display-advancedgraphics">this screen</a> or <a href="https://obsproject.com/wiki/How-to-disable-Windows-10-Hardware-GPU-Scheduler">these instructions</a>."""]
 
 def checkNVENC(lines):
     msgs = search("Failed to open NVENC codec", lines)
@@ -1117,6 +1121,7 @@ def doAnalysis(url=None, filename=None):
             messages.append(checkOpenGLonWindows(logLines))
             messages.append(checkGameDVR(logLines))
             messages.append(checkGameMode(logLines))
+            messages.append(checkWin10Hags(logLines))
             m = checkVideoSettings(logLines)
             for sublist in m:
                 if sublist is not None:


### PR DESCRIPTION
HAGS is currently known to cause severe performance and capture issues with some users and must be disabled

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Adds critical warning when HAGS is turned on
Comes with a suitable Wiki page: https://github.com/obsproject/obs-studio/wiki/How-To-Disable-Windows-10-Hardware-GPU-Scheduler

### Motivation and Context
Several performance issues when this is on. Needs probably a few more Windows or driver updates before it's negative impact is gone. There is currently no software or game that makes use of this feature in any way.

### How Has This Been Tested?
Used a log with and without HAGS
- HAGS On - https://obsproject.com/logs/HSDADanYZu0S_xKI 
- HAGS Off - https://obsproject.com/logs/jyRFYM7zL3jPUmmY 
- No HAGS entry (random log) - https://obsproject.com/logs/pul7ZWuk6h0D9H6D

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
