### PR TITLE
Add dynamic bitrate checks

### DIFF
--- a/checks/network.py
+++ b/checks/network.py
@@ -57,3 +57,19 @@ def checkNICSpeed(lines):
                     if 'GbE' in nic or 'Gigabit' in nic:
                         return [LEVEL_WARNING, "Slow Network Connection", "Your gigabit-capable network card is only connecting at 100mbps. This may indicate a bad network cable or outdated router / switch which could be impacting network performance."]
     return None
+
+
+x264stream_re = re.compile(r"stream")
+
+
+def checkDynamicBitrate(lines):
+    dynBrLines = search('Dynamic bitrate enabled', lines)
+    if (len(dynBrLines) > 0):
+        x264Lines = search('x264 encoder: ', lines)
+        for i in x264Lines:
+            if x264stream_re.search(i):
+                return [LEVEL_INFO, "Dynamic Bitrate", "Dynamic Bitrate is enabled. Instead of dropping frames when network issues are detected, OBS will automatically reduce the stream quality to compensate. The bitrate will adjust back to normal once the connection becomes stable. In some (very specific) situations, Dynamic Bitrate can get stuck at a low bitrate. If this happens frequently, it is recommended to turn off Dynamic Bitrate in Settings -> Advanced -> Network."]
+        else:
+            return [LEVEL_WARNING, "Dynamic Bitrate",
+                    """Dynamic Bitrate is enabled and a hardware encoder is potentially in use. This can cause issues with hardware encoders if bitrate changes happen too frequently, or drops too low. Should you experience bitrate dropping to zero, or no output even if OBS says its streaming, either change your Encoder to x264 or turn off Dynamic Bitrate in Settings -> Advanced -> Network."""]
+    return None

--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -164,6 +164,7 @@ def doAnalysis(url=None, filename=None):
                 checkGameMode(logLines),
                 checkWin10Hags(logLines),
                 checkNICSpeed(logLines),
+                checkDynamicBitrate(logLines),
             ])
             messages.extend(checkVideoSettings(logLines))
             m = parseScenes(logLines)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This adds checks for dynamic bitrate and non x264 encoders. Checks for dynamic bitrate, and if present checks for non-x264 encoders. Depending on the out the encoders found, an INFO or WARNING will be returned.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Users dont always understand the implications of enabling dynamic bitrate, especially the challenges that might occur when non-x264 encoders are in use. This not only inform users of of the fact and explains it to them, and also adds helpful information for support volunteers.

Seeing as most hardware encoders are prone to crashing or issues with dynamic bitrate in certain circumstances, a warning when using dynamic bitrate + non-x264 encoders will hopefully lead users to be more informed about the issues and consider other options. Should hopefully also lessen the load slightly on support volunteers

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Running the simplehttp server on my machine, and testing the changes with the following:

Dynamic Bitrate:
nvenc simple: <https://obsproject.com/logs/y74C5azqJ41JGJf_>
nvenc advanced: https://obsproject.com/logs/zrjWLYYT7AfcBN9I
x264 advanced: https://obsproject.com/logs/xwFM8BJxgYmokzpU
x264 simple: https://obsproject.com/logs/S88uiveJ9RkGE2rL

Traditional (static) bitrate:
nvenc simple: https://obsproject.com/logs/IwTB2NMiFki8b4Li
nvenc advanced: https://obsproject.com/logs/kJdSr142_eME2naX
x264 advanced: https://obsproject.com/logs/wTYC6l2rErqI_E5O
x264 simple: https://obsproject.com/logs/A35DaXzD2SpmePiz

When streamFX encoders (ffmpeg) is in use for streaming, no "dynamic bitrate" message is output to the log. All checks are just ignored.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
