### PR TITLE
Add check for Stream Delay

### DIFF
--- a/checks/network.py
+++ b/checks/network.py
@@ -73,3 +73,10 @@ def checkDynamicBitrate(lines):
             return [LEVEL_WARNING, "Dynamic Bitrate",
                     """Dynamic Bitrate is enabled and a hardware encoder is potentially in use. This can cause issues with hardware encoders if bitrate changes happen too frequently, or drops too low. Should you experience bitrate dropping to zero, or no output even if OBS says its streaming, either change your Encoder to x264 or turn off Dynamic Bitrate in Settings -> Advanced -> Network."""]
     return None
+
+
+def checkStreamDelay(lines):
+    delayLines = search('second delay active', lines)
+    if (len(delayLines) > 0):
+        return [LEVEL_INFO, "Stream Delay", "Stream Delay may currently be active. This means that your stream is being delayed by a certain number of seconds. If this is not what you intended, please disable it in Settings -> Advanced -> Stream Delay."]
+    return None

--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -165,6 +165,7 @@ def doAnalysis(url=None, filename=None):
                 checkWin10Hags(logLines),
                 checkNICSpeed(logLines),
                 checkDynamicBitrate(logLines),
+                checkStreamDelay(logLines),
             ])
             messages.extend(checkVideoSettings(logLines))
             m = parseScenes(logLines)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Added a simple check that searches for `second delay active` in log lines. If found, create an Info message.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
There are several users that seem to accidentally manage to trigger the delay on their stream without being aware of the consequence. This is just meant as a heads up/reminder that it is enabled, and explains to them what it is, and how to potentially disable it.

It also makes it easier for support people to notice the delay.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Using the simple web server, I ran it thru the following logs:

Simple mode:
Delay off: <https://obsproject.com/logs/5ByyTBd-fgyDodaB>
Delay on: <https://obsproject.com/logs/mwvDT0XwbmKaJ3P9>

Advanced mode:
Delay off: <https://obsproject.com/logs/JY_tQ9E5wwmLVXFC>
Delay on: <https://obsproject.com/logs/e7d-mfCm3Ash3HYg>

It produces the expected output, and does not crash.
Tested on Win10 only, OBS 27 RC3.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.