### PR TITLE
Add search for what encoder is being used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ ENV/
 .idea/
 
 .vscode/
+
+# other
+.DS_Store

--- a/checks/encoding.py
+++ b/checks/encoding.py
@@ -100,7 +100,12 @@ def checkEncodeError(lines):
 
 
 def checkEncoding(lines):
-    drops = search('skipped frames', lines)
+    hasx264 = len(search('[x264 encoder:', lines))
+    hasNVENC = (len(search('[jim-nvenc:', lines)) + len(search('[NVENC encoder:', lines)))
+    hasAMD = (len(search('[AMF] [H264]', lines)) + len(search('[AMF] [H265]', lines)))
+    hasQSV = len(search('[qsv encoder:', lines))
+    hasAPPLE = (len(search('[VideoToolbox recording_h264:', lines)) + len(search('[VideoToolbox streaming_h264:', lines)))
+    drops = len(search('skipped frames', lines))
     val = 0
     severity = 9000
     for drop in drops:
@@ -115,5 +120,15 @@ def checkEncoding(lines):
             severity = LEVEL_WARNING
         else:
             severity = LEVEL_INFO
-        return [severity, "{}% Encoder Overload".format(val),
-                """Encoder overload may be related to your CPU or GPU being overloaded, depending on the encoder in question. If you are using a software encoder (x264) please see the <a href="https://obsproject.com/wiki/General-Performance-and-Encoding-Issues">CPU Overload Guide</a>. If you are using a hardware encoder (AMF, QSV/Quicksync, NVENC) please see the <a href="https://obsproject.com/wiki/GPU-overload-issues">GPU Overload Guide</a>."""]
+        if ((hasx264 + hasAMD + hasQSV + hasNVENC + hasAPPLE) > 1):
+            return [severity, "{}% Encoder Overload".format(val),
+                    """Encoder overload may be related to your CPU or GPU being overloaded, depending on the encoder in question. If you are using a software encoder (x264) please see the <a href="https://obsproject.com/wiki/General-Performance-and-Encoding-Issues">CPU Overload Guide</a>. If you are using a hardware encoder (AMF, QSV/Quicksync, NVENC) please see the <a href="https://obsproject.com/wiki/GPU-overload-issues">GPU Overload Guide</a>."""]
+        elif (hasx264 > 0):
+            return [severity, "{}% CPU Encoder Overload".format(val),
+                    """The encoder is skipping frames because of CPU overload. Read about <a href="https://obsproject.com/wiki/General-Performance-and-Encoding-Issues">General Performance and Encoding Issues</a>."""]
+        elif ((hasNVENC + hasAMD + hasQSV + hasAPPLE) > 0):
+            return [severity, "{}% GPU Encoder Overload".format(val),
+                    """The encoder is skipping frames because of GPU overload. Read about <a href="https://obsproject.com/wiki/GPU-overload-issues">GPU Overload Guide</a>."""]
+        else:
+            return [severity, "{}% Encoder Overload".format(val),
+                    """Encoder overload may be related to your CPU or GPU being overloaded, depending on the encoder in question. If you are using a software encoder (x264) please see the <a href="https://obsproject.com/wiki/General-Performance-and-Encoding-Issues">CPU Overload Guide</a>. If you are using a hardware encoder (AMF, QSV/Quicksync, NVENC) please see the <a href="https://obsproject.com/wiki/GPU-overload-issues">GPU Overload Guide</a>."""]

--- a/formatcode.sh
+++ b/formatcode.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+autopep8 --in-place -r .
+
+./check_pep8.sh
+if [ $? != 0 ]
+then
+    echo "Code couldn't be formatted correctly. Try fixing the issue(s) above yourself."
+    exit 1
+fi


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Searches for what encoder is being used if there is encoding overload and spits out the correct guide for them to follow to fix it. If it detects multiple encoders it will spit out the old message, but if it only detects one encoder in the log, it will spit out the correct guide for that encoder. it also specifies in the name of the message if it is GPU or CPU Encoding Overload and if multiple encoders are detected it just calls it Encoding Overload. This part was to make it easier to know which it is from the bot message in discord. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This will make it easier for people to troubleshoot encoding overload based on what encoder they are using. This was the best building block I could think of after #70 but before doing a full tiered encoder grouping which seems really complicated and would require deep, deep digging. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
tested on my machine using simplehttp.py and multiple logs including but not only: 
https://obsproject.com/logs/d6PFgXPTkav2T4wG 
https://obsproject.com/logs/lWYBmu4Hxd-n8WjW 
https://obsproject.com/logs/TTbKxy95c2hWt0ET
https://obsproject.com/logs/V_Osm0MVosz6EczT

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
