### PR TITLE
Re-Add Info about StreamElements

### DIFF
--- a/checks/plugins.py
+++ b/checks/plugins.py
@@ -4,5 +4,5 @@ from .utils.utils import *
 
 def checkElements(lines):
     if (len(search('obs-streamelements', lines)) > 0):
-        return [LEVEL_WARNING, "StreamElements OBS.Live",
-                """The obs.live plugin is installed. This overwrites OBS' default browser source and causes a severe performance impact. To get rid of it, first, export your scene collections and profiles, second manually uninstall OBS completely, third reinstall OBS Studio only with the latest installer from <a href="https://obsproject.com/download">https://obsproject.com/download</a>"""]
+        return [LEVEL_INFO, "StreamElements OBS.Live",
+                """StreamElements' OBS.live plugin is installed. This interferes with OBS' browser source and can cause performance impacts. If you want to remove it, follow their <a href="https://streamelements.elevio.help/en/articles/4-how-do-i-uninstall-the-obs-live-plugin">uninstall instructions</a> (make sure that "User Settings" is <b>not</b> selected), then reinstall OBS Studio using only the latest installer from <a href="https://obsproject.com/download">https://obsproject.com/download</a>."""]


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Re-Adds the check regarding StreamElements' obs.live plugin, however
as a LEVEL_INFO and with wording less hostile than before, making it
clear that while it can cause issues in certain scenarios, it isn't
always at fault.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This once was a warning-level check, but got removed due to it sounding overly hostile and apparently some volunteers stopped providing support the moment they saw something about obs.live.
I still find it to be very useful to see, for example if someone asks about the browser not working - immediately seeing that .live is installed could speed up the process of sending them to SE significantly.

I considered the following writing this PR:
- The check-level is changed form warning to info, to not directly imply that it is something bad.
- The description worded in a more friendly way, not telling the user that the plugin *causes a severe performance impact* and that they should *get rid of it* as fast as they can. Instead, it is described that yes, it breaks the browser source, and that it can impact performance, but implied that it doesn't necessarily do so. All this is to say that the plugin *can* be a problem, but doesn't have to be.
- The uninstall instructions got replaced by a link to the ones in SE's own knowledge base - mainly to not clog up all the text with uninstall instructions
- Regarding volunteers refusing to help: Once they click on a log, they see the plugin anyways - sometimes even before clicking on the log since the Bot might offer a cleaned up version of such log. I personally don't think that adding the check would change the situation to the worse, though I do see how that could be disputed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 11.2.3
Ran both the httpserver and standalone-analyzer, correctly identifying whether obs.live was installed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
