### PR TITLE
Add Windows 11 Insider detection

### DIFF
--- a/checks/windows.py
+++ b/checks/windows.py
@@ -272,9 +272,14 @@ def checkWindowsVer(lines):
 
     # This is such a hack, but it's unclear how to do this better
     if verinfo["version"] == "10.0" and verinfo["release"] == 0:
-        msg = "You are running an unknown Windows 10 release (build %d), which means you are probably using an Insider build. Some checks that are applicable only to specific Windows versions will not be performed. Also, because Insider builds are test versions, you may have problems that would not happen with release versions of Windows." % (
-            verinfo["build"])
-        return[LEVEL_WARNING, "Windows 10 Version Unknown", msg]
+        if verinfo["build"] >= 22000:
+            msg = "You are running Windows 11 Insider build %d. Some checks that are applicable only to specific Windows versions will not be performed. Also, because Insider builds are test versions, you may have problems that would not happen with release versions of Windows 10." % (
+                verinfo["build"])
+            return[LEVEL_WARNING, "Windows 11 Insider Build", msg]
+        else:
+            msg = "You are running an unknown Windows 10 release (build %d), which means you are probably using an Insider build. Some checks that are applicable only to specific Windows versions will not be performed. Also, because Insider builds are test versions, you may have problems that would not happen with release versions of Windows." % (
+                verinfo["build"])
+            return[LEVEL_WARNING, "Windows 10 Version Unknown", msg]
 
     if "EoS" in verinfo and datetime.date.today() > verinfo["EoS"]:
         wv = "%s (EOL)" % (html.escape(verinfo["name"]))


### PR DESCRIPTION
### Description
Add Windows 11 Insider detection

### Motivation and Context
The first version of Windows 11 Insider Preview is out with the build number 22000.     
Any Windows builds with build number greater than 22000 should be Windows 11.  
But Windows 11 is not released to the public yet, so we can safely assume all Windows 11 build will be Insider builds. 


### How Has This Been Tested?
![image](https://user-images.githubusercontent.com/7903172/124369692-4d67f200-dc34-11eb-898c-579450609fb7.png)


### Types of changes
- New feature (non-breaking change which adds functionality)


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
