### PR TITLE
Remove warning for hw encoders in dynamic bitrate

### DIFF
--- a/checks/network.py
+++ b/checks/network.py
@@ -59,19 +59,10 @@ def checkNICSpeed(lines):
     return None
 
 
-x264stream_re = re.compile(r"stream")
-
-
 def checkDynamicBitrate(lines):
     dynBrLines = search('Dynamic bitrate enabled', lines)
     if (len(dynBrLines) > 0):
-        x264Lines = search('x264 encoder: ', lines)
-        for i in x264Lines:
-            if x264stream_re.search(i):
-                return [LEVEL_INFO, "Dynamic Bitrate", "Dynamic Bitrate is enabled. Instead of dropping frames when network issues are detected, OBS will automatically reduce the stream quality to compensate. The bitrate will adjust back to normal once the connection becomes stable. In some (very specific) situations, Dynamic Bitrate can get stuck at a low bitrate. If this happens frequently, it is recommended to turn off Dynamic Bitrate in Settings -> Advanced -> Network."]
-        else:
-            return [LEVEL_WARNING, "Dynamic Bitrate",
-                    """Dynamic Bitrate is enabled and a hardware encoder is potentially in use. This can cause issues with hardware encoders if bitrate changes happen too frequently, or drops too low. Should you experience bitrate dropping to zero, or no output even if OBS says its streaming, either change your Encoder to x264 or turn off Dynamic Bitrate in Settings -> Advanced -> Network."""]
+        return [LEVEL_INFO, "Dynamic Bitrate", "Dynamic Bitrate is enabled. Instead of dropping frames when network issues are detected, OBS will automatically reduce the stream quality to compensate. The bitrate will adjust back to normal once the connection becomes stable. In some (very specific) situations, Dynamic Bitrate can get stuck at a low bitrate. If this happens frequently, it is recommended to turn off Dynamic Bitrate in Settings -> Advanced -> Network."]
     return None
 
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This removes the warning for dynamic bitrate when using hardware encoders.
Will leave this as a draft (and a reminder) until the next OBS release, and we've gotten confirmation of the hardware encoders now work in a stable manner on more machines.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Now that https://github.com/obsproject/obs-studio/pull/5169 has been merged, and assuming it works well, there is no longer a reason to put up warnings for its usage with hardware encoders.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Running the simplehttp server on my machine, and testing the changes with the following:

Dynamic Bitrate:
nvenc simple: <https://obsproject.com/logs/y74C5azqJ41JGJf_>
nvenc advanced: https://obsproject.com/logs/zrjWLYYT7AfcBN9I
x264 advanced: https://obsproject.com/logs/xwFM8BJxgYmokzpU
x264 simple: https://obsproject.com/logs/S88uiveJ9RkGE2rL

Traditional (static) bitrate:
nvenc simple: https://obsproject.com/logs/IwTB2NMiFki8b4Li
nvenc advanced: https://obsproject.com/logs/kJdSr142_eME2naX
x264 advanced: https://obsproject.com/logs/wTYC6l2rErqI_E5O
x264 simple: https://obsproject.com/logs/A35DaXzD2SpmePiz

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
