### PR TITLE
Simplify version detection

### DIFF
--- a/checks/core.py
+++ b/checks/core.py
@@ -49,13 +49,8 @@ def getOBSVersionLine(lines):
 
 def getOBSVersionString(lines):
     versionLine = getOBSVersionLine(lines)
-    if versionLine.split()[0] == 'OBS':
-        versionString = versionLine.split()[1]
-    elif versionLine.split()[2] == 'OBS':
-        versionString = versionLine.split()[3]
-    else:
-        versionString = versionLine.split()[2]
-    return versionString
+    versionString = versionLine[versionLine.find("OBS"):]
+    return versionString.split()[1]
 
 
 obsver_re = re.compile(r"""


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This commit changes how the version detection works by removing everything in the version lines not relevant to version detection.

The current 3 cases essentially cover whether:
* the log was uploaded in-app, resulting in an additional logs line like:
  `OBS 27.1.0~rc2 (linux) log file uploaded at 2021-09-14, 10:22:24`
* the log was uploaded otherwise, resulting in the logged version being detected:
  `01:46:09.110: OBS 27.0.1 (64-bit, windows)`
* there are weird edge-cases with malformed/different timestamps (but obviously not all of them)

Instead of working our way around the various ways timestamps could be presented, this instead removes everything before "OBS" (which should be only the timestamp), and we can focus purely on the version itself, which is then always `split()[1]` (and if it's not, it's a custom build).

#### Concerns:
Custom builds with "OBS" being prefixed would not get detected.
That said, with the current logic they would also not be detected:
```
echo "ti:me:st.amp: MyOBS 27.1.0-rc2 (linux)" > log && ./loganalyzer.py -f log
echo "ti:me:st.amp: My OBS 27.1.0-rc2 (linux)" > log && ./loganalyzer.py -f log"
```
Both are detected as RCs:
```
Info:     Release Candidate OBS Version (27.1.0-rc2), No Output Session, No Scenes/Sources
```
Reason being that we only search for "OBS" in the line. The first test would be caught by the catch-all-case, the second test by the `split()[2]` case.

Effectively this PR doesn't change anything in detecting custom builds.
Neither is a good solution, but of course it can always be seen in the actual log file.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Lately there have been more and more logs on the discord that contain version lines like this:
```
08:38:13 AM IST.733: OBS 27.0.1-2 (linux)
```
The issue is that none of the current checks support this type of timestamp and we just fall through to the catch-all, resulting in this:

Unparseable OBS Version (IST.733:)

[Example here](https://obsproject.com/tools/analyzer?log_url=https%3A%2F%2Fcdn.discordapp.com%2Fattachments%2F636682839382949888%2F887175774149423134%2Fmessage.txt)

With this patch, the version is correctly detected (albeit in this case recognised as "Custom"):
Custom OBS Build (27.0.1-2)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

By taking various logs posted on Discord and running them through the analyser locally. Tested logs include:
* [The aforementioned example](https://cdn.discordapp.com/attachments/636682839382949888/887175774149423134/message.txt)
* [A log from the current RC](https://cdn.discordapp.com/attachments/880514476896579644/885150676051697724/2021-09-08_17-48-26.txt)
* [An unparseable version](https://obsproject.com/logs/lTapT43KU_Odgyqc)
* [A Windows log from #windows-support](https://cdn.discordapp.com/attachments/374636015396192257/887245641590407188/2021-09-14_13-19-55.txt)
* [A Mac OS log from #macos-support](https://cdn.discordapp.com/attachments/636682784156549152/887181126421074010/2021-09-13_22-05-00.txt)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
