### PR TITLE
Fix Encoder overload detection on multiple encodes

### DIFF
--- a/checks/encoding.py
+++ b/checks/encoding.py
@@ -121,7 +121,7 @@ def checkEncoding(lines):
             severity = LEVEL_WARNING
         else:
             severity = LEVEL_INFO
-        if ((hasx264 + hasAMD + hasQSV + hasNVENC + hasAPPLE) > 1):
+        if (hasx264 > 0 and (hasAMD + hasQSV + hasNVENC + hasAPPLE) > 0):
             return [severity, "{}% Encoder Overload".format(val),
                     """Encoder overload may be related to your CPU or GPU being overloaded, depending on the encoder in question. If you are using a software encoder (x264) please see the <a href="https://obsproject.com/wiki/General-Performance-and-Encoding-Issues">CPU Overload Guide</a>. If you are using a hardware encoder (AMF, QSV/Quicksync, NVENC) please see the <a href="https://obsproject.com/wiki/GPU-overload-issues">GPU Overload Guide</a>."""]
         elif (hasx264 > 0):


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

When starting multiple encoding sessions with NVENC (or other hardware
encoder) and receiving encoder overload, it was still reported as
"Encoder Overload", and not specifically as "GPU Encoder Overload".

Reason being: We count lines for each encoder. We then add those up and
check if the count is greater then 1. This check is intended for
mixed-encoder logs (i.e. x264 + any hardware encoder). However as 2
encoding sessions of any encoder is already greater then 1, we get
caught on the first case and never get to the further cases.

Essentially we only want to check if both types of encoders were used at least once.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

It was mentioned and asked on Discord why a double NVENC log showed up as "Encoder Overload", and not "GPU Encoder Overload" specifically. Looking at the code it made sense to fix it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Using the following logs:
[Double NVENC](https://obsproject.com/logs/DKlfT4gG5-QDjAZk) (original report)
[Mixed Encoders](https://obsproject.com/logs/DjAXadQF8uy-qAJg)
[Double x264](https://obsproject.com/logs/pI5b9G8QOfeqsbcT)

Note the last 2 were faked using some string replacement in the original log, but that shouldn't be a big deal since we know what the analyzer is looking for.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
