### PR TITLE
Fix issue on Wayland checks with timestamp format

### DIFF
--- a/checks/wayland.py
+++ b/checks/wayland.py
@@ -24,12 +24,12 @@ def checkWayland(lines):
     if not sessionTypeLine:
         return
 
-    sessionType = sessionTypeLine.split()[3]
-    if sessionType != 'wayland':
+    isWayland = sessionTypeLine[sessionTypeLine.find('wayland'):]
+    if isWayland != 'wayland':
         return
 
-    distro = isDistroNix[0].split()
-    if distro[2] == '"Ubuntu"' and distro[3] == '"20.04"':
+    distro = isDistroNix[0][isDistroNix[0].find('"Ubuntu" "20.04"'):]
+    if distro == '"Ubuntu" "20.04"':
         return [LEVEL_CRITICAL, "Ubuntu 20.04 under Wayland",
                 "Ubuntu 20.04 does not provide the needed dependencies for OBS to capture under Wayland.<br> So OBS is able to capture only under X11/Xorg."]
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix issue on Wayland checks with timestamp format

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This [log](https://obsproject.com/logs/Wtfvbnrd7NenBFvD) didn't trigger XWayland warning because of the timestamp format, so I tried to fix it.

The Ubuntu 20.04 check is also fixed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- With the [log](https://obsproject.com/logs/eKb1Q19JR-Hq82Jd) of #81 
- And the [log](https://obsproject.com/logs/Wtfvbnrd7NenBFvD) that didn't trigger it
- And this [discord log](https://cdn.discordapp.com/attachments/636682839382949888/887175774149423134/message.txt) under X11 doesn't cause any issue

Since I didn't have Ubuntu 20.04 logs, I temporarily replaced 20.04 by 21.04 for testing the check.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
