### PR TITLE
Windows 10/11 21H2 End of Service Date

### DIFF
--- a/checks/utils/windowsversions.py
+++ b/checks/utils/windowsversions.py
@@ -17,11 +17,13 @@ winver_re = re.compile(r"""
     """, re.VERBOSE)
 
 
+# Ref: https://docs.microsoft.com/en-us/lifecycle/products/windows-11-home-and-pro-version-21h2
 win11versions = {
     22000: {
         "release": 2009,
-        "name": "Windows 11",
+        "name": "Windows 11 21H2",
         "date": datetime.date(2021, 10, 5),
+        "EoS": datetime.date(2023, 10, 10),
     }
 }
 
@@ -30,6 +32,8 @@ win11versions = {
 # calls them "versions" because Win10 is also "Version 10.0".
 #
 # We probably don't need all the info here, but it comes in handy
+#
+# Ref: https://docs.microsoft.com/en-us/lifecycle/products/windows-10-home-and-pro
 win10versions = {
     10240: {
         "release": 1507,
@@ -108,6 +112,7 @@ win10versions = {
         "release": 2009,
         "name": "Windows 10 21H2",
         "date": datetime.date(2021, 10, 5),
+        "EoS": datetime.date(2023, 6, 13),
     },
     **win11versions
 }

--- a/checks/windows.py
+++ b/checks/windows.py
@@ -86,7 +86,7 @@ def checkRefreshes(lines):
     if verinfo["version"] == "10.0" and "release" not in verinfo:
         return
 
-    # FINALLY fixed in WIn10/2004
+    # FINALLY fixed in Win10/2004
     if verinfo["version"] and verinfo["release"] >= 2004:
         return
 
@@ -272,8 +272,8 @@ def checkWindowsVer(lines):
 
     # This is such a hack, but it's unclear how to do this better
     if verinfo["version"] == "10.0" and verinfo["release"] == 0:
-        if verinfo["build"] >= 22000:
-            msg = "You are running Windows 11 Insider build %d. Some checks that are applicable only to specific Windows versions will not be performed. Also, because Insider builds are test versions, you may have problems that would not happen with release versions of Windows 10." % (
+        if verinfo["build"] > 22000:
+            msg = "You are running Windows 11 Insider build %d. Some checks that are applicable only to specific Windows versions will not be performed. Also, because Insider builds are test versions, you may have problems that would not happen with release versions of Windows 11." % (
                 verinfo["build"])
             return[LEVEL_WARNING, "Windows 11 Insider Build", msg]
         else:


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Add Windows 11 and 10 21H2 EoS date.

### Motivation and Context
Windows 11 is released on October 5th, 2021.

### How Has This Been Tested?
![Web capture_26-1-2022_3550_localhost](https://user-images.githubusercontent.com/7903172/151134495-ad825294-bad8-43b1-8847-9c45a40a083e.jpeg)
![Web capture_26-1-2022_3724_localhost](https://user-images.githubusercontent.com/7903172/151134502-97473e69-302b-4cb9-b37d-fa5261b5a526.jpeg)



### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
