### PR TITLE
Fix NVENC low stream bitrate threshold

### DIFF
--- a/checks/encoding.py
+++ b/checks/encoding.py
@@ -69,26 +69,33 @@ def checkNVENC(lines):
 
 
 def checkStreamSettingsNVENC(lines):
+    videoSettings = []
+    fps_num, fps_den = 0, 1
+    for i, s in enumerate(lines):
+        if "video settings reset:" in s:
+            videoSettings.append(i)
+    if (len(videoSettings) > 0):
+        for i in range(7):
+            chunks = lines[videoSettings[-1] + i].split()
+            if (chunks[-2] == 'fps:'):
+                fps_num, fps_den = (int(x) for x in chunks[-1].split('/'))
     streamingSessions = []
     for i, s in enumerate(lines):
         if "[NVENC encoder: 'streaming_h264'] settings:" in s:
             streamingSessions.append(i)
     if (len(streamingSessions) > 0):
         bitrate = 0
-        fps_num = 0
         width = 0
         height = 0
         for i in range(12):
             chunks = lines[streamingSessions[-1] + i].split()
             if (chunks[-2] == 'bitrate:'):
                 bitrate = float(chunks[-1])
-            elif (chunks[-2] == 'keyint:'):
-                fps_num = float(chunks[-1])
             elif (chunks[-2] == 'width:'):
                 width = float(chunks[-1])
             elif (chunks[-2] == 'height:'):
                 height = float(chunks[-1])
-        bitrateEstimate = (width * height * fps_num) / 20000
+        bitrateEstimate = (width * height * fps_num / fps_den) / 20000
         if (bitrate < bitrateEstimate):
             return [LEVEL_INFO, "Low Stream Bitrate",
                     "Your stream encoder is set to a video bitrate that is too low. This will lower picture quality especially in high motion scenes like fast paced games. Use the Auto-Config Wizard to adjust your settings to the optimum for your situation. It can be accessed from the Tools menu in OBS, and then just follow the on-screen directions."]


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Frame rate was wrongly taken from `keyint` reported by the NVENC streaming session. The frame rate is corrected to be taken from the global video settings.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
According to a discussion on Discord, the stream bitrate is too high but it is reported too low.
https://discord.com/channels/348973006581923840/374636015396192257/912208926836129862

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with the same log file and confirmed the `Low Stream Bitrate` is no more reported.
https://obsproject.com/logs/MljccFMDFkUc0w5t

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

Assuming `keyint` is usually set to 2 seconds, this change may increase amount of ` Low Stream Bitrate`.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
