### PR TITLE
Graphics: Add P010 as valid color format

### DIFF
--- a/checks/graphics.py
+++ b/checks/graphics.py
@@ -66,9 +66,9 @@ def checkVideoSettings(lines):
         if ((not ((1.77 < baseAspect) and (baseAspect < 1.7787))) or (not ((1.77 < outAspect) and (outAspect < 1.7787)))):
             res.append([LEVEL_WARNING, "Non-Standard Aspect Ratio",
                         "Almost all modern streaming services and video platforms expect video in 16:9 aspect ratio. OBS is currently configured to record in an aspect ratio that differs from that. You (or your viewers) will see black bars during playback. Go to Settings -> Video and change your Canvas Resolution to one that is 16:9."])
-        if (fmt != 'NV12'):
+        if (fmt != 'NV12' and fmt != 'P010'):
             res.append([LEVEL_CRITICAL, "Wrong Color Format",
-                        "Color Formats other than NV12 are primarily intended for recording, and are not recommended when streaming. Streaming may incur increased CPU usage due to color format conversion. You can change your Color Format in Settings -> Advanced."])
+                        "Color Formats other than NV12 and P010 are primarily intended for recording, and are not recommended when streaming. Streaming may incur increased CPU usage due to color format conversion. You can change your Color Format in Settings -> Advanced."])
         if (not ((fps == 60) or (fps == 30))):
             res.append([LEVEL_WARNING, "Non-Standard Framerate",
                         "Framerates other than 30fps or 60fps may lead to playback issues like stuttering or screen tearing. Stick to either of these for better compatibility with video players. You can change your OBS frame rate in Settings -> Video."])


### PR DESCRIPTION

### Description
Modifies the color format check to accept P010 as valid. Added P010 to the user facing text.

### Motivation and Context
People using P010 to stream is now a valid usecase for HDR (youtube HLS livestreaming for instance).

It does not incur "incur increased CPU usage due to color format conversion" as the other formats might.

### How Has This Been Tested?
Tested with the following logs, and made sure NV12 and P010 clears the check.

P010:
https://obsproject.com/logs/vPvBonXWjLqVG0xb

i420:
https://obsproject.com/logs/BaS5cg2eV1V27NfL

nv12:
https://obsproject.com/logs/kLjH6O7qIoGSUPY2

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
