### PR TITLE
Core: Remove i3 trigger

### DIFF
--- a/checks/core.py
+++ b/checks/core.py
@@ -32,9 +32,6 @@ def checkCPU(lines):
         if (('APU' in cpu[0]) or ('Pentium' in cpu[0]) or ('Celeron' in cpu[0])):
             return [LEVEL_CRITICAL, "Insufficient Hardware",
                     "Your system is below minimum specs for OBS to run and may be too underpowered to livestream. There are no recommended settings we can suggest, but try the Auto-Config Wizard in the Tools menu. You may need to upgrade or replace your computer for a better experience."]
-        elif ('i3' in cpu[0]):
-            return [LEVEL_INFO, "Insufficient Hardware",
-                    "Your system is below minimum specs for OBS to run and is too underpowered to livestream using software encoding. Livestreams and recordings may run more smoothly if you are using a hardware encoder like QuickSync, NVENC or AMF (via Settings -> Output)."]
 
 
 def getOBSVersionLine(lines):


### PR DESCRIPTION


### Description
Removes the i3 trigger.

### Motivation and Context
Modern i3 models are no longer considered underpowered.

Comparison to a 2nd gen ryzen 5: <https://www.cpubenchmark.net/compare/Intel-Core-i3-12100F-vs-AMD-Ryzen-5-2600X/4670vs3235>

### How Has This Been Tested?
Ran simplehttp. Tested my own log as well as https://obsproject.com/logs/HIMr4cfWGGHTj5_2


### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
