### PR TITLE
Exclude venv and pycache from pycodestyle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [pycodestyle]
 ignore = E501, E722
-exclude = __init__
+exclude = __init__, venv, env, .venv, ENV, __pycache__


### PR DESCRIPTION
### Description
Adds excluded directories from being processed pep8.
* venv and .venv
* env and ENV
* __pycache__

Mostly aligned with what is in .gitignore.

### Motivation and Context
Don't want it to check those dirs. Easier to run when you don't have to specify individual files or folders. Prior to this change, if you run pycodestyle.exe --config=setup.cfg . on win , it would check venv, and of course spew out hundreds of issues from deps/pips.

### How Has This Been Tested?
On win10 22H2. Confirmed the excluded directories don't get checked (no errors from the deps/pips).

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
