### PR TITLE
Graphics: Update color range wording

### DIFF
--- a/checks/graphics.py
+++ b/checks/graphics.py
@@ -84,5 +84,5 @@ def checkVideoSettings(lines):
                         "Recording at a tremendously high framerate will not give you higher quality recordings. Usually quite the opposite. Most computers cannot handle encoding at high framerates. You can change your OBS frame rate in Settings -> Video."])
         if 'Full' in yuv:
             res.append([LEVEL_WARNING, "Wrong YUV Color Range",
-                        """Having the YUV Color range set to "Full" will cause playback issues in certain browsers and on various video platforms. Shadows, highlights and color will look off. In OBS, go to "Settings -> Advanced" and set "YUV Color Range" back to "Partial"."""])
+                        """Having the YUV Color range set to "Full" will cause playback issues in certain browsers and on various video platforms. Shadows, highlights and color will look off. In OBS, go to "Settings -> Advanced" and set "YUV Color Range" back to "Limited"."""])
     return res


### PR DESCRIPTION
### Description
Updates the wording for color range.
In OBS, we no longer call it Partial, its now Limited.

### Motivation and Context
Don't want users to be confused that they can't find the option we tell them to set.

### How Has This Been Tested?
https://obsproject.com/logs/ZUFRyCvpM9NYMhIC

On win, with this log.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
