### PR TITLE
Add a check for multiple plugins being logged on one line

### DIFF
--- a/checks/plugins.py
+++ b/checks/plugins.py
@@ -36,7 +36,7 @@ def checkPluginList(lines):
         thirdPartyPlugins = []
 
         for s in pluginList:
-            if ('     ' in s):
+            if ('     ' in s and s.count(':') == 3):
                 pluginFormatter = s.split(' ')
                 pluginFormatter = pluginFormatter[-1].split('.')
                 thirdPartyPlugins.append(pluginFormatter[0])


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This adds a count check for the number of ":" in a line. A plugin line should only have 3 of these so this ignores lines that have more or less. A more ideal fix would be to prevent this plugin and others like it from logging inside the `Loaded Modules` section at all but that is beyond my ability and outside the scope of the analyzer code.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Saw this log resulting in an incorrectly listed plugin on the log analyzer page:

https://obsproject.com/logs/H9kyOhPqQEOwEXeW
https://obsproject.com/tools/analyzer?log_url=https%3A%2F%2Fobsproject.com%2Flogs%2FH9kyOhPqQEOwEXeW

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally with the above log to confirm this is resolved.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
