### PR TITLE
Fix third-party plugins parsing

### DIFF
--- a/checks/plugins.py
+++ b/checks/plugins.py
@@ -36,10 +36,11 @@ def checkPluginList(lines):
         thirdPartyPlugins = []
 
         for s in pluginList:
-            if ('     ' in s):
-                pluginFormatter = s.split(' ')
-                pluginFormatter = pluginFormatter[-1].split('.')
-                thirdPartyPlugins.append(pluginFormatter[0])
+            if '     ' in s:
+                timestamp, plugin = s.split(': ', 1)
+                plugin = plugin.rsplit('.', 1)[0]
+                plugin = plugin.strip()
+                thirdPartyPlugins.append(plugin)
 
         thirdPartyPlugins = set(thirdPartyPlugins).difference(commonPlugins)
         if (checkOperatingSystem(lines) == "windows"):


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This fixes a parsing issue that was resulting in a plugin name being incorrectly displayed on the analyzer results page.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I saw this log in the support discord: https://obsproject.com/logs/XmQtglRbVpBW3YfN

It parses obs_shaderfilter_plus_windows_x64 (1).dll as (1) currently but parses correctly after these changes.

This also fixes pastebin links which were adding \r to the string being read by the plugin formatter:
https://pastebin.com/bUGt5L46

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with the above logs to confirm the fix and then various other logs to check for unexpected issues. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
