### PR TITLE
windows: Fix GPU check for custom OBS versions

### DIFF
--- a/checks/windows.py
+++ b/checks/windows.py
@@ -9,19 +9,14 @@ from .utils.windowsversions import *
 
 
 def checkGPU(lines):
-    versionString = getOBSVersionString(lines)
-    if parse_version(versionString) < parse_version('23.2.1'):
-        adapters = search('Adapter 1', lines)
+    adapters = []
+    for i in range(3):
         try:
-            adapters.append(search('Adapter 2', lines)[0])
+            adapters.append(search(f"Adapter {i}", lines)[0])
+            print(adapters)
         except IndexError:
             pass
-    else:
-        adapters = search('Adapter 0', lines)
-        try:
-            adapters.append(search('Adapter 1', lines)[0])
-        except IndexError:
-            pass
+
     d3dAdapter = search('Loading up D3D11', lines)
     if (len(d3dAdapter) > 0):
         if (len(adapters) == 2 and ('Intel' in d3dAdapter[0]) and ('Arc' not in d3dAdapter[0])):


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When analyzing a log for a custom OBS version, the version string comparison would result in checkGPU thinking that the version in the log was less than '23.2.1'. This resulted in using the pre-23.2.1 adapter indexes, which started at 1 instead of 0. This, in turn, resulted in the analyzer thinking that there was only one GPU in the system. If OBS is running on the dGPU, Adapter 1 would often be the iGPU. If this iGPU was an Intel iGPU, the analyzer would emit an "Integrated GPU" warning.

Instead of basing the adapter indices on the OBS version, which may have required processing the OBS version string or adding new version string processing functions, we can simply try adapter indexes 0-2 and treat index 0 as if it were possible that it doesn't exist with a try-except on each call as we already did for one call in each branch. This resolves the erroneous "Integrated GPU" warning when processing a log from a "Custom OBS Build" or any other version that results in its version string evaluating as less than 23.2.1.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Saw this coming up with logs from the Twitch Enhanced Broadcasting beta. Wanted to try to resolve it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally with a log from the Twitch Enhanced Broadcasting Beta. You can mimic this with any normal OBS log by adding extra characters to the version string, such as "-custom-obs-whatever-v99":
> 21:10:39.995: OBS 30.1.0-custom-obs-whatever-v99 (64-bit, windows)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
