### PR TITLE
windows: Fix check32bitOn64bit

### DIFF
--- a/checks/windows.py
+++ b/checks/windows.py
@@ -343,7 +343,7 @@ def checkAdmin(lines):
 def check32bitOn64bit(lines):
     winVersion = search('Windows Version', lines)
     obsVersion = getOBSVersionLine(lines)
-    if (len(winVersion) > 0 and '64-bit' in winVersion[0] and '64-bit' not in obsVersion and '64bit' not in obsVersion):
+    if (len(winVersion) > 0 and '64-bit' in winVersion[0] and ('32-bit' in obsVersion or '32bit' in obsVersion)):
         # thx to secretply for the bugfix
         return [LEVEL_WARNING, "32-bit OBS on 64-bit Windows",
                 "You are running the 32 bit version of OBS on a 64 bit system. This will reduce performance and greatly increase the risk of crashes due to memory limitations. You should only use the 32 bit version if you have a capture device that lacks 64 bit drivers. Please run OBS using the 64-bit shortcut."]


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
For OBS Studio 29.1.0-beta1, 64-bit OBS did not output "64-bit" in its logs. While this was fixed for OBS Studio 29.1.0-beta2, the check as it is currently would probably also catch a hypothetical native WoA (Windows-on-ARM) build. Additionally, the change in this commit is what the live log analyzer has been running for about a year. Checking for the presence of the undesired indicator ("32-bit" or "32bit") seems more correct than checking for the absence of the desired indicator ("64-bit" or "64bit").

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want the checks to be correct. Want the live log analyzer to be in sync with this repo.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested a log from OBS Studio 29.1.0-beta1 locally to make sure this didn't regress.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
