### PR TITLE
Update marian-code/python-lint-annotate to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Annotate linting errors
-        uses: marian-code/python-lint-annotate@v2
+        uses: marian-code/python-lint-annotate@ffe24b32a33241b668ab6d34150d7d8e1ad744ec
         with:
           python-root-list: "."
           use-black: false
@@ -51,7 +51,7 @@ jobs:
           use-flake8: false
           use-vulture: false
           extra-pycodestyle-options: "--config=setup.cfg"
-          conda-python-version: "3.8"
+          python-version: "3.8"
       - name: Run pycodestyle
         # This is required because the annotate action doesn't trigger a failure
         run: |


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Update marian-code/python-lint-annotate to v4.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Update the last remaining action to a modern version based on node20. The action's v2 somewhat avoided this, but was generally outdated, while its v3 still used the outdated node16.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on my fork. Verified that v3 emitted node16 warnings while v4 did not.

https://github.com/RytoEX/loganalyzer/actions/runs/8652789123
https://github.com/RytoEX/loganalyzer/actions/runs/8652846033

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
