### PR TITLE
core: Fix OBS version reported as unparseable

### DIFF
--- a/checks/core.py
+++ b/checks/core.py
@@ -47,18 +47,15 @@ def checkCPU(lines):
 
 def getOBSVersionLine(lines):
     versionLines = search('OBS', lines)
-    correctLine = 0
-    if 'uploaded' in versionLines[correctLine]:
-        correctLine += 1
-    if 'already running' in versionLines[correctLine]:
-        correctLine += 1
-    if 'multiple instances' in versionLines[correctLine]:
-        correctLine += 1
-    if 'windows from screen capture' in versionLines[correctLine]:
-        correctLine += 1
-    if 'Lenovo Vantage / Legion Edge is installed' in versionLines[correctLine]:
-        correctLine += 1
-    return versionLines[correctLine]
+    wrongLines = ('uploaded',
+                  'already running',
+                  'multiple instances',
+                  'windows from screen capture',
+                  'Lenovo Vantage / Legion Edge is installed')
+    for line in versionLines:
+        if not any(wrongLine in line for wrongLine in wrongLines):
+            return line
+    return versionLines[-1]
 
 
 def getOBSVersionString(lines):


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This changes the `getOBSVersionLine` function to be less reliant on the ordering of the lines in the OBS log.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Due to the Lenovo vantage reporting being printed to log before the "hide from screen capture" one, the log analyzer reported an unparseable obs version for any log which had detected lenovo vantage.
An example log can be found [here](https://obsproject.com/logs/p6E9BB5QwEklBJKX).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This was tested manually by feeding the lines to the function and checking it returns the correct one.
If only"wrong" lines are found it will return the last one so as to return something.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
