### PR TITLE
core: Fix version detection with Flatpak VKCapture

### DIFF
--- a/checks/core.py
+++ b/checks/core.py
@@ -51,7 +51,8 @@ def getOBSVersionLine(lines):
                   'already running',
                   'multiple instances',
                   'windows from screen capture',
-                  'Lenovo Vantage / Legion Edge is installed')
+                  'Lenovo Vantage / Legion Edge is installed',
+                  'com.obsproject')
     for line in versionLines:
         if not any(wrongLine in line for wrongLine in wrongLines):
             return line


### PR DESCRIPTION
### Description
`getOBSVersionLine()` was finding:
`<timestamp>:  - com.obsproject.Studio.Plugin.OBSVkCapture` for users with this extension, therefore `getOBSVersionString()` ran into an IndexError on splitting the (invalid) `versionString`.

Therefore filtering out any lines that contain the Flatpak identifier.

### Motivation and Context
Noticed Discord Bot noping out on some logs, fixed it.

### How Has This Been Tested?
Before:
```
$ ./loganalyzer.py -u https://obsproject.com/logs/PgEsS0ZxLEhOqgfO
Traceback (most recent call last):
  File "/home/tarulia/Development/obs-loganalyser/./loganalyzer.py", line 221, in <module>
    main()
  File "/home/tarulia/Development/obs-loganalyser/./loganalyzer.py", line 215, in main
    msgs = doAnalysis(url=flags.url, filename=flags.file)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tarulia/Development/obs-loganalyser/./loganalyzer.py", line 131, in doAnalysis
    checkObsVersion(logLines),
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tarulia/Development/obs-loganalyser/checks/core.py", line 83, in checkObsVersion
    versionString = getOBSVersionString(lines)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tarulia/Development/obs-loganalyser/checks/core.py", line 64, in getOBSVersionString
    return versionString.split()[1]
           ~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

After:
```
$ ./loganalyzer.py -u https://obsproject.com/logs/PgEsS0ZxLEhOqgfO
Critical: 37.5% Rendering Lag
Warning:  
Info:     Third-Party Plugins (7)

--------------------------------------
 
Details

Critical:
37.5% Rendering Lag
    Your GPU is maxed out and OBS can't render scenes fast enough. Running a
    game without vertical sync or a frame rate limiter will frequently cause
    performance issues with OBS because your GPU will be maxed out. OBS requires
    a little GPU to render your scene. <br><br>Enable Vsync or set a reasonable
    frame rate limit that your GPU can handle without hitting 100% usage.
    <br><br>If that's not enough you may also need to turn down some of the
    video quality options in the game. If you are experiencing issues in general
    while using OBS, your GPU may be overloaded for the settings you are trying
    to use.<br><br>Please check our guide for ideas why this may be happening,
    and steps you can take to correct it: <a
    href="https://obsproject.com/kb/encoding-performance-troubleshooting">GPU
    Overload Issues</a>. 

Warning: 

Info:
Third-Party Plugins (7)
    You have the following third-party plugins installed:<br><ul><li>droidcam-
    obs<br><li>vertical-canvas<br><li>linux-vkcapture<br><li>input-
    overlay<br><li>RewardsTheater<br><li>obs-
    backgroundremoval<br><li>waveform</ul>
```

Also threw in a Windows and Mac log from Discord to check that it doesn't break on those.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
