### PR TITLE
core: Add OBSBasic to version line exclusions

### DIFF
--- a/checks/core.py
+++ b/checks/core.py
@@ -52,7 +52,8 @@ def getOBSVersionLine(lines):
                   'multiple instances',
                   'windows from screen capture',
                   'Lenovo Vantage / Legion Edge is installed',
-                  'com.obsproject')
+                  'com.obsproject',
+                  'OBSBasic')
     for line in versionLines:
         if not any(wrongLine in line for wrongLine in wrongLines):
             return line


### PR DESCRIPTION

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds OBSBasic to the wrongLines array so it will be excluded from the version check.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixed OBS 30.2+ log analysis, will fail to parse otherwise.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with a 30.2 beta log https://obsproject.com/logs/rOvTTkjkAXfnWIE3

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
