### PR TITLE
core: Use regex to parse OBS version

### DIFF
--- a/checks/core.py
+++ b/checks/core.py
@@ -46,16 +46,10 @@ def checkCPU(lines):
 
 
 def getOBSVersionLine(lines):
+    versionPattern = re.compile(r': OBS \d+\.\d+\.\d+')
     versionLines = search('OBS', lines)
-    wrongLines = ('uploaded',
-                  'already running',
-                  'multiple instances',
-                  'windows from screen capture',
-                  'Lenovo Vantage / Legion Edge is installed',
-                  'com.obsproject',
-                  'OBSBasic')
     for line in versionLines:
-        if not any(wrongLine in line for wrongLine in wrongLines):
+        if versionPattern.search(line):
             return line
     return versionLines[-1]
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove the wrongLines list in favor of using regex to target the specific version line. My regex is not great so there is a chance I am over simplifying it but this is what I have gotten to work through trial and error. I am happy to change the regex if a better option is presented but this covers all of the different cases in the logs that I was able to find.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This will allow for less maintenance in the future to prevent the analyzer from crashing if a new line is logged before the OBS version is that includes "OBS". 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested the following logs, all with various versions from different versions dating back to 0.0.1 on Linux.
https://obsproject.com/logs/g9mDoXFJfiQvUsyH
https://obsproject.com/logs/Oj9J1vvGlDykmesH
https://obsproject.com/logs/ubenZ416XhbHkMO8
https://obsproject.com/logs/GCDHNloD7RwdZs_f
https://obsproject.com/logs/Ua29dmO45t8vlsVS

These logs were not only picked for the different version numbers but also because they have instances of other checks that use the version string such as the 32-bit OBS on 64-bit windows check.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
