### PR TITLE
linux: Unified system info summary

### DIFF
--- a/checks/linux.py
+++ b/checks/linux.py
@@ -14,6 +14,34 @@ def getWindowSystemLine(lines):
         return windowSystem[0]
 
 
+def isWayland(lines):
+    if not (checkDistro(lines) or checkFlatpak(lines)):
+        return False
+
+    sessionTypeLine = getSessionTypeLine(lines)
+    if not sessionTypeLine:
+        return False
+
+    if 'wayland' not in sessionTypeLine:
+        return False
+
+    return True
+
+
+def isX11(lines):
+    if not (checkDistro(lines) or checkFlatpak(lines)):
+        return False
+
+    sessionTypeLine = getSessionTypeLine(lines)
+    if not sessionTypeLine:
+        return False
+
+    if 'x11' not in sessionTypeLine:
+        return False
+
+    return True
+
+
 def checkDistro(lines):
     isDistroNix = search('Distribution:', lines)
 
@@ -47,23 +75,13 @@ def checkSnapPackage(lines):
 
 
 def checkWayland(lines):
-    isDistroNix = search('Distribution:', lines)
-    isFlatpak = search('Flatpak Runtime:', lines)
-
-    if (len(isDistroNix) <= 0) and (len(isFlatpak) <= 0):
+    if not isWayland(lines):
         return
 
-    sessionTypeLine = getSessionTypeLine(lines)
-    if not sessionTypeLine:
-        return
-
-    if 'wayland' not in sessionTypeLine:
-        return
-
-    if len(isDistroNix) > 0:
-        if '"Ubuntu" "20.04"' in isDistroNix[0]:
-            return [LEVEL_CRITICAL, "Ubuntu 20.04 under Wayland",
-                    "Ubuntu 20.04 does not provide the needed dependencies for OBS to capture under Wayland.<br> Capture will only function under X11/Xorg."]
+    isDistroNix = checkDistro(lines)
+    if isDistroNix and ('"Ubuntu" "20.04"' in isDistroNix[1]):
+        return [LEVEL_CRITICAL, "Ubuntu 20.04 under Wayland",
+                "Ubuntu 20.04 does not provide the needed dependencies for OBS to capture under Wayland.<br> Capture will only function under X11/Xorg."]
 
     windowSystemLine = getWindowSystemLine(lines)
     # If there is no Window System, OBS is running under Wayland
@@ -80,21 +98,9 @@ def checkWayland(lines):
                 <a href='https://wiki.archlinux.org/title/XDG_Desktop_Portal'>XDG Desktop Portal</a><br>
                 Note that the availability of Window and/or Display capture depends on your Desktop Environment's implementation of these portals."""]
 
-    return [LEVEL_INFO, "Wayland", ""]
-
 
 def checkX11Captures(lines):
-    isDistroNix = search('Distribution:', lines)
-    isFlatpak = search('Flatpak Runtime:', lines)
-
-    if (len(isDistroNix) <= 0) and (len(isFlatpak) <= 0):
-        return
-
-    sessionTypeLine = getSessionTypeLine(lines)
-    if not sessionTypeLine:
-        return
-
-    if 'x11' not in sessionTypeLine:
+    if not isX11(lines):
         return
 
     # obsolete PW sources
@@ -108,8 +114,6 @@ def checkX11Captures(lines):
                 """Most Desktop Environments do not implement the PipeWire capture portals on X11. This can result in being unable to pick a window or display, or the selected source will stay empty.<br><br>
                 We generally recommend using \"Window Capture (Xcomposite)\" on X11, as \"Display Capture (XSHM)\" can introduce bottlenecks depending on your setup."""]
 
-    return [LEVEL_INFO, "X11", ""]
-
 
 def checkDesktopEnvironment(lines):
     isDistroNix = search('Distribution:', lines)
@@ -119,6 +123,10 @@ def checkDesktopEnvironment(lines):
         return
 
     desktopEnvironmentLine = search('Desktop Environment:', lines)
+
+    if not desktopEnvironmentLine:
+        return
+
     desktopEnvironment = desktopEnvironmentLine[0].split()
 
     if (len(desktopEnvironment) > 3):
@@ -167,3 +175,34 @@ def checkLinuxVCam(lines):
         return [LEVEL_INFO, "Virtual Camera not available",
                 """Using the Virtual Camera requires the <code>v4l2loopback</code> kernel module to be installed.<br>
                 If required, please refer to our <a href="https://github.com/obsproject/obs-studio/wiki/install-instructions#prerequisites-for-all-versions">Install Instructions</a> on how to install this on your distribution."""]
+
+
+def listLinuxSystemInfo(lines):
+    if checkFlatpak(lines):
+        linuxDistroOrFlatpak = 'Flatpak'
+        linuxSystemInfoHelp = checkFlatpak(lines)[2] + '<br>'
+    elif checkDistro(lines):
+        linuxDistroOrFlatpak = 'Distribution: ' + checkDistro(lines)[1]
+        linuxSystemInfoHelp = ''
+    else:
+        # I have never seen this, but you never know
+        linuxDistroOrFlatpak = '⚠️  None'
+        linuxSystemInfoHelp = 'No distribution detected. This can lead to undefined behaviour. Please consult your distribution\'s support channels on how to fix this.<br>'
+
+    if isX11(lines):
+        displayServer = 'X11'
+    elif isWayland(lines):
+        displayServer = 'Wayland'
+    else:
+        # can happen with misconfigured or virtual systems
+        displayServer = '⚠️  None'
+        linuxSystemInfoHelp += 'No Display Server detected. This can lead to undefined behaviour. Please consult your Desktop Environment\'s or Window Manager\'s support channels on how to fix this.<br>'
+
+    if checkDesktopEnvironment(lines):
+        desktopEnvironment = 'DE: ' + checkDesktopEnvironment(lines)[1]
+    else:
+        # can happen for some misconfigured tiling window managers
+        desktopEnvironment = '⚠️  None'
+        linuxSystemInfoHelp += 'No Desktop Environment detected. This can lead to undefined behaviour. Please consult your Desktop Evironment\'s or Window Manager\'s support channels on how to fix this.'
+
+    return [LEVEL_INFO, linuxDistroOrFlatpak + ' | ' + displayServer + ' | ' + desktopEnvironment, linuxSystemInfoHelp]

--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -182,14 +182,12 @@ def doAnalysis(url=None, filename=None):
                 checkVantage(logLines),
                 checkPortableMode(logLines),
                 checkSafeMode(logLines),
-                checkDistro(logLines),
-                checkFlatpak(logLines),
                 checkSnapPackage(logLines),
                 checkX11Captures(logLines),
-                checkDesktopEnvironment(logLines),
                 checkMissingModules(logLines),
                 checkLinuxVCam(logLines),
-                checkMacPermissions(logLines)
+                checkMacPermissions(logLines),
+                listLinuxSystemInfo(logLines)
             ])
             messages.extend(checkVideoSettings(logLines))
             m = parseScenes(logLines)


### PR DESCRIPTION
### Description
After the merging of #161 Linux logs output (typically) 3 separate bullet points for the system information (Distro, Display Server, Desktop Environment), which looks odd and lengthens the page or bot summary.

Since all are merely informational and without help texts, this combines all 3 points into a single one. The Flatpak extension helptext is shown alongside it when appropriate.

For this I chose to extract the simple X11/Wayland checks into their own functions to make them reusable in other check functions.

### Motivation and Context
It was noted on Discord in the `#documentation` channel that the current presentation looks - for lack of a better word - "weird" and might lead users to think that the output is bugged.

Of course the output works exactly as intended because it was primarily meant for OBS Bot output. However I was thinking about shortening the OBS Bot output anyway, but at the time of the PR I just didn't think of this fairly simple solution.

### How Has This Been Tested?
I used the same logs as used in #161 to check that there were no regressions in the output. Additionally I used a manually altered log to test:
```sh
#!/bin/bash

echo "===== Snap ====="
./loganalyzer.py --url "https://obsproject.com/logs/a8VNcRHD4vjHol3P"

echo "===== Flatpak ====="
./loganalyzer.py --url "https://obsproject.com/logs/MXdrIL75xKFyPNom"

echo "===== Wayland ====="
./loganalyzer.py --url "https://obsproject.com/logs/MXdrIL75xKFyPNom"

echo "===== XWayland ====="
./loganalyzer.py --url "https://obsproject.com/logs/1FaZYJAAwOsKvUxX"

echo "===== Wayland + no pipewire ====="
./loganalyzer.py --url "https://obsproject.com/logs/CN9BBx9uPPjBcGlA"

echo "===== X11 ====="
./loganalyzer.py --url "https://obsproject.com/logs/jBUCYqPE5LRHMRHB"

echo "===== X11 + PipeWire sources ====="
./loganalyzer.py --url "https://obsproject.com/logs/MQhnzM1TFjBgdxrO"

echo "===== Ubuntu 20.04 on Wayland ====="
./loganalyzer.py --url "https://obsproject.com/logs/xU4dQ1JTcnSJFnvx"

echo "===== Borked Log ====="
./loganalyzer.py --file "borked.log"
```

```
$ cat borked.log
04:10:50.647: Command Line Arguments: --enable-media-stream --disable-shutdown-check --enable-multitrack-video-dev --remote-debugging-port=8080 --remote-allow-origins=http://localhost:8080
04:10:50.647: Using EGL/X11
04:10:50.647: CPU Name: AMD Ryzen 9 5900X 12-Core Processor
04:10:50.647: CPU Speed: 3545.114MHz
04:10:50.648: Physical Cores: 12, Logical Cores: 24
04:10:50.648: Physical Memory: 15895MB Total, 1922MB Free
04:10:50.648: Kernel Version: Linux 6.12.9-200.fc41.x86_64
04:10:50.648: Window System: X11.0, Vendor: The X.Org Foundation, Version: 1.21.1
04:10:50.649: Qt Version: 6.8.1 (runtime), 6.8.1 (compiled)
04:10:50.649: Portable mode: false
04:10:50.684: OBS 31.0.1 (linux)
04:10:50.684: ---------------------------------
04:10:50.710: ---------------------------------
04:10:50.710: audio settings reset:
04:10:50.710: 	samples per sec: 48000
04:10:50.710: 	speakers:        2
04:10:50.710: 	max buffering:   960 milliseconds
04:10:50.710: 	buffering type:  dynamically increasing
04:10:50.718: ---------------------------------
04:10:50.718: Initializing OpenGL...
04:10:50.762: Loading up OpenGL on adapter AMD AMD Radeon RX 7700 XT (radeonsi, navi32, LLVM 19.1.5, DRM 3.59, 6.12.9-200.fc41.x86_64)
04:10:50.762: OpenGL loaded successfully, version 4.6 (Core Profile) Mesa 24.3.3, shading language 4.60
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
