### PR TITLE
simplehttp: Update event loop usage for Python 3.11+

### DIFF
--- a/simplehttp.py
+++ b/simplehttp.py
@@ -8,7 +8,7 @@ from aiohttp import web
 import json
 import loganalyzer as analyze
 
-loop = asyncio.get_event_loop()
+loop = asyncio.new_event_loop()
 threadPool = futures.ThreadPoolExecutor(thread_name_prefix='loganalyzer: worker thread')
 app = web.Application()
 
@@ -195,6 +195,7 @@ def main():
         logging.info('Exiting application.')
         applicationTask.cancel()  # Shuts down the HTTP server
         threadPool.shutdown()  # Shuts down the running thread pool
+        loop.close()  # Close the event loop
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Update event loop usage for Python 3.11+.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Corrects/Updates event loop usage to address this warning:
```
simplehttp.py:11: DeprecationWarning: There is no current event loop
loop = asyncio.get_event_loop()
```

However, this surfaces new errors when quitting the application:
```
ResourceWarning: unclosed event loop <ProactorEventLoop running=False closed=False debug=False>
```
Adding a `loop.close()` to the end of the `finally` block resolves this.

However, other errors persist:
```
[ERROR] [default_exception_handler] Task was destroyed but it is pending!
task: <Task pending name='Task-3' coro=<IocpProactor.accept.<locals>.accept_coro() running at pythoncore-3.14-64\Lib\asyncio\windows_events.py:567> wait_for=<_OverlappedFuture cancelled>>
[ERROR] [default_exception_handler] Task was destroyed but it is pending!
task: <Task pending name='Task-4' coro=<IocpProactor.accept.<locals>.accept_coro() running at pythoncore-3.14-64\Lib\asyncio\windows_events.py:567> wait_for=<_OverlappedFuture cancelled>>
<sys>:0: ResourceWarning: unclosed <socket.socket fd=872, family=2, type=1, proto=0, laddr=('127.0.0.1', 8084)>
<sys>:0: ResourceWarning: unclosed <socket.socket fd=736, family=2, type=1, proto=0>
<sys>:0: ResourceWarning: unclosed <socket.socket fd=748, family=23, type=1, proto=0, laddr=('::1', 8084, 0, 0)>
<sys>:0: ResourceWarning: unclosed <socket.socket fd=508, family=23, type=1, proto=0>
[ERROR] [default_exception_handler] Task was destroyed but it is pending!
task: <Task cancelling name='Task-1' coro=<_run_app() running at .venv\Lib\site-packages\aiohttp\web.py:423> wait_for=<Future cancelled>>
```

However, these only occur on exit, and I'm not familiar enough with Python asyncio dev to address them.

Python 3.10:
https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop
https://docs.python.org/3.10/library/asyncio-eventloop.html#hello-world-with-call-soon

Python 3.11:
https://docs.python.org/3.11/library/asyncio-eventloop.html#asyncio.get_event_loop
https://docs.python.org/3.11/library/asyncio-eventloop.html#hello-world-with-call-soon

Python 3.14:
https://docs.python.org/3.14/library/asyncio-eventloop.html#asyncio.get_event_loop
https://docs.python.org/3.14/library/asyncio-eventloop.html#hello-world-with-call-soon

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally on Windows with Python 3.11 and 3.14.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
